### PR TITLE
feat(server): simplify public API

### DIFF
--- a/proto/core.proto
+++ b/proto/core.proto
@@ -3,48 +3,27 @@ syntax = "proto3";
 package core;
 
 service RelayService {
-    rpc PerformAutoTest (AutoTestSubmissionRequest) returns (AutoTestSubmissionResponse);
-    rpc CheckStyle (CheckStyleRequest) returns (CheckStyleResponse);
-    rpc SubmitWork (SubmissionRequest) returns (SubmissionResponse);
+    rpc Command(CommandRequest) returns (CommandResponse) {}
 }
 
-message CodeSegment {
+message File {
     string file_name = 1;
     bytes data = 2; // The actual data of the source code file.
 }
 
-message AutoTestSubmissionRequest {
-    string course_code = 1; // The specific course autotest binary (such as `1511`).
-    string test_name = 2; // The name of the test to be run.
-    repeated CodeSegment code_segments = 3; // The source code files to be compiled and run.
-    string main_file = 4; // The name of the main file to be run.
+message Directory {
+    string name = 1;
+    repeated File files = 2;
+    repeated Directory directories = 3;
 }
 
-message AutoTestSubmissionResponse {
-    string test_name = 1; // The name of the test that was run.
-    int32 text_exit_code = 2; // The status of the test.
-    string test_output = 3; // The stdout and stderr of the test.
+message CommandRequest {
+    string command = 1;
+    repeated string arguments = 2;
+    Directory directory = 3; // represents the root dir (cwd)
 }
 
-message CheckStyleRequest {
-    repeated CodeSegment code_segments = 1; // The source code files to be checked.
-    string main_file = 2; // The name of the main file to be checked.
-}
-
-message CheckStyleResponse {
-    int32 exit_code = 1; // The status of the checkstyle run.
-    string output = 2; // The stdout and stderr of the checkstyle run.
-}
-
-message SubmissionRequest {
-    string course_code = 1; // The specific course to submit to (such as `cs1511`).
-    string problem = 2; // The name of the problem that the submission is for.
-    repeated CodeSegment code_segments = 3; // The source code files to be compiled and submitted.
-    string main_file = 4; // The name of the main file to be run.
-}
-
-message SubmissionResponse {
-    string course_code = 1; // The specific course to submit to (such as `cs1511`).
-    string problem = 2; // The name of the problem that the submission is for.
-    bool success = 3; // Whether the submission was successful.
+message CommandResponse {
+    string output = 1;
+    int64 exit_code = 2;
 }

--- a/proto/websocket.proto
+++ b/proto/websocket.proto
@@ -9,27 +9,20 @@ message InitFrame {
     string token = 2; // the student's token, used to login to the server
 }
 
-message Task {
+message TaskRequest {
     string id = 1;
-    oneof data {
-        core.AutoTestSubmissionRequest autotest_submission_request = 2;
-        core.AutoTestSubmissionResponse autotest_submission_response = 3;
-        core.CheckStyleRequest check_style_request = 4;
-        core.CheckStyleResponse check_style_response = 5;
-        core.SubmissionRequest submission_request = 6;
-        core.SubmissionResponse submission_response = 7;
-    }
+    core.CommandRequest command = 2;
+}
+
+message TaskResponse {
+    string id = 1;
+    core.CommandResponse response = 2;
 }
 
 message SocketFrame {
-    enum Opcode {
-        AUTOTEST_SUBMISSION_REQUEST = 0;
-        AUTOTEST_SUBMISSION_RESPONSE = 1;
-        CHECK_STYLE_REQUEST = 2;
-        CHECK_STYLE_RESPONSE = 3;
-        SUBMISSION_REQUEST = 4;
-        SUBMISSION_RESPONSE = 5;
+    oneof data {
+        InitFrame init = 1;
+        TaskRequest task_request = 2;
+        TaskResponse task_response = 3;
     }
-    Opcode opcode = 1;
-    Task task = 2;
 }

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,4 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=../proto/*");
+
     tonic_build::compile_protos("../proto/core.proto")?;
     tonic_build::compile_protos("../proto/websocket.proto")?;
     Ok(())

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -1,16 +1,8 @@
 use tonic::{Request, Response, Status};
-use tracing::error;
+use tracing::{error, instrument};
 
 use crate::{
-    relay::core::{
-        relay_service_server::RelayService,
-        AutoTestSubmissionRequest,
-        AutoTestSubmissionResponse,
-        CheckStyleRequest,
-        CheckStyleResponse,
-        SubmissionRequest,
-        SubmissionResponse,
-    },
+    relay::core::{relay_service_server::RelayService, CommandRequest, CommandResponse},
     MANAGER,
 };
 
@@ -18,46 +10,28 @@ pub(crate) mod interceptors;
 #[derive(Debug, Default)]
 pub struct Relay {}
 
-macro_rules! handle_rpc {
-    ($request:expr, $mgr:expr, $task:ident) => {{
-        let meta = $request.metadata().clone();
+#[tonic::async_trait]
+impl RelayService for Relay {
+    #[instrument]
+    async fn command(
+        &self,
+        request: Request<CommandRequest>,
+    ) -> Result<Response<CommandResponse>, Status> {
+        let meta = request.metadata().clone();
         let zid = meta.get("zid").unwrap().to_str().unwrap();
 
-        let mgr = $mgr.get().unwrap();
-        let result = mgr.$task(zid, $request.into_inner()).await;
+        let mgr = MANAGER.get().unwrap();
+        let result = mgr.forward_task(zid, request.into_inner()).await;
 
         match result {
             Ok(v) => Ok(Response::new(v)),
             Err(e) => {
                 error!("{:?}", e);
                 Err(Status::unavailable(
-                    "failed to run tests; please try again later",
+                    // TODO: more detailed error messages
+                    "failed to forward task; please try again later",
                 ))
             },
         }
-    }};
-}
-
-#[tonic::async_trait]
-impl RelayService for Relay {
-    async fn perform_auto_test(
-        &self,
-        request: Request<AutoTestSubmissionRequest>,
-    ) -> Result<Response<AutoTestSubmissionResponse>, Status> {
-        handle_rpc!(request, MANAGER, autotest)
-    }
-
-    async fn submit_work(
-        &self,
-        request: Request<SubmissionRequest>,
-    ) -> Result<Response<SubmissionResponse>, Status> {
-        handle_rpc!(request, MANAGER, submission)
-    }
-
-    async fn check_style(
-        &self,
-        request: Request<CheckStyleRequest>,
-    ) -> Result<Response<CheckStyleResponse>, Status> {
-        handle_rpc!(request, MANAGER, check_style)
     }
 }

--- a/server/src/ws/messaging/mod.rs
+++ b/server/src/ws/messaging/mod.rs
@@ -1,90 +1,78 @@
 use std::net::SocketAddr;
 
-use prost::bytes::Bytes;
-use tokio_tungstenite::tungstenite::Message as WSMessage;
-use tracing::{info, instrument, warn};
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{instrument, warn};
 
-use super::PeerMap;
 use crate::{
-    client_manager::tasks::CoreMessage,
-    relay::ws_extensions::{task::Data, SocketFrame},
+    relay::ws_extensions::{socket_frame::Data, SocketFrame},
     MANAGER,
 };
 
 mod operations;
 
-macro_rules! handle_task_data {
-    ($manager:expr, $id:expr, $response_type:ident, $data:expr) => {
-        $manager
-            .tasks
-            .complete_task($id, CoreMessage::$response_type($data))
-            .await;
-    };
-}
-
 /// Handle a message from a peer. This is called for each message received from
 /// each peer.
-#[instrument(skip(peer_map))]
-pub(crate) async fn handle_message(peer_map: PeerMap, msg: WSMessage, address: SocketAddr) {
+#[instrument]
+pub(crate) async fn handle_message(msg: Message, address: SocketAddr) {
     // every peer must register themselves with the server before anything else can
     // take place.
 
+    let peer_map = MANAGER.get().unwrap().peers.clone();
     let mut peer_map = peer_map.lock().await;
     let peer = peer_map
         .get_mut(&address)
         .expect("peer was not in the peer map");
 
-    // TODO: handle initial client registering
-    // check if the peer is registered
-    match &peer.data {
-        Some(pd) => {
-            // peer is registered, handle the message
-            info!("[ws] received message from peer user: `{}`", pd.username);
+    if let Message::Binary(binary) = msg {
+        // determine if the peer has been registered
+        let not_registered = peer.data.is_none();
 
-            // message should be binary
-            if let WSMessage::Binary(binary) = msg {
-                // attempt to decode the message into a SocketFrame
-                if let Ok(frame) = <SocketFrame as prost::Message>::decode(Bytes::from(binary)) {
-                    if frame.task.is_none() || frame.task.as_ref().unwrap().data.is_none() {
-                        // invalid message, no task
-                        warn!(
-                            "[ws] received invalid message from peer user: `{}`",
-                            pd.username
-                        );
-                        return;
-                    }
+        // attempt to decode the message
+        let message = match <SocketFrame as prost::Message>::decode(binary.as_ref()) {
+            Ok(message) if message.data.is_some() => message.data.unwrap(),
+            _ => {
+                // peers should not be sending malformed requests, so we
+                // close the connection with a policy error
+                warn!("[ws] error decoding socket frame");
+                peer.close_with_policy();
+                return;
+            },
+        };
 
-                    let task = frame.task.unwrap();
-                    let task_data = task.data.unwrap();
-
-                    let manager = MANAGER.get().unwrap();
-                    // we can ignore opcode since rust processes enum variants :sunglasses:
-                    // TODO: validate opcode
-                    match task_data {
-                        Data::CheckStyleResponse(data) => {
-                            handle_task_data!(manager, task.id, CheckStyleResponse, data);
-                        },
-                        Data::AutotestSubmissionResponse(data) => {
-                            handle_task_data!(manager, task.id, AutoTestSubmissionResponse, data);
-                        },
-                        Data::SubmissionResponse(data) => {
-                            handle_task_data!(manager, task.id, SubmissionResponse, data);
-                        },
-                        _ => todo!(),
-                    }
-                } else {
-                    warn!(
-                        "[ws] failed to decode protobuf from peer user: `{}`",
-                        pd.username
-                    );
-                }
+        // if the peer is not registered, check if the packet is a InitFrame
+        if not_registered {
+            if let Data::Init(frame) = message {
+                operations::handle_registration(peer, address, frame).await;
             } else {
-                warn!(
-                    "[ws] received non-binary message from peer user: `{}`",
-                    pd.username
-                );
+                // unregistered peers should not be sending non-init frames
+                warn!("[ws] unregistered peer sent non-init frame");
+                peer.close_with_policy();
             }
-        },
-        None => operations::handle_registration(peer, msg, address),
+        } else {
+            // peer is registered; handle message accordingly
+            match message {
+                Data::Init(_) => {
+                    // registered clients should not be sending init frames
+                    warn!("[ws] registered peer sent init frame");
+                    // so we will close it because sus
+                    peer.close_with_policy();
+                },
+                Data::TaskRequest(_) => {
+                    // runners should not be sending task requests to the server
+                    warn!("[ws] runner sent task request");
+                    peer.close_with_policy();
+                },
+                Data::TaskResponse(response) => {
+                    // signal to the task manager that this task has been completed
+                    let manager = MANAGER.get().unwrap();
+                    manager.tasks.complete_task(response).await;
+                },
+            }
+        }
+    } else {
+        // this service does not deal with any other message types since
+        // everything should be serialised in protocol buffer wire encoding
+        warn!("[ws] received message from peer: {:#}", msg);
+        peer.close_with_policy();
     }
 }

--- a/server/src/ws/messaging/operations.rs
+++ b/server/src/ws/messaging/operations.rs
@@ -1,50 +1,14 @@
+#![allow(clippy::pedantic)]
 use std::net::SocketAddr;
 
-use prost::bytes::Bytes;
-use tokio_tungstenite::tungstenite::Message;
-use tracing::{info, warn};
-
-use crate::{
-    relay::ws_extensions::InitFrame,
-    ws::{models, models::Peer},
-};
+use crate::{relay::ws_extensions::InitFrame, ws::models::Peer};
 
 /// Handle a registration message from a peer.
-pub(crate) fn handle_registration(peer: &mut Peer, msg: Message, address: SocketAddr) {
-    // attempt to register the peer
-    // check the message type
-    if let Message::Binary(data) = msg {
-        // attempt to decode it into an InitFrame
-        if let Ok(frame) = <InitFrame as prost::Message>::decode(Bytes::from(data)) {
-            // TODO: check if the frame is valid (i.e. validate code with database and
-            // all that)
-            // We will assume it's fine for the time being
-            let data = models::PeerData {
-                token:    frame.token,
-                username: frame.zid,
-            };
-
-            if data.token.is_empty() {
-                warn!("[ws] peer attempted to register with invalid token");
-                peer.close_with_policy();
-                return;
-            }
-
-            // store the data
-            info!("[ws] peer `{}`", data.username);
-            peer.data = Some(data);
-        } else {
-            warn!("[ws] failed to decode init frame from peer: {}", address);
-            // TODO: we should be closing with policy, but for testing
-            // purposes we will auth the client
-            // peer.close_with_policy()
-            peer.data = Some(models::PeerData {
-                token:    "dummy".to_string(),
-                username: "dummy".to_string(),
-            });
-        }
-    } else {
-        // the peer is not attempting to validate; close the connection
-        peer.close_with_policy();
-    }
+pub(crate) async fn handle_registration(
+    _peer: &mut Peer,
+    _address: SocketAddr,
+    _message: InitFrame,
+) {
+    // TODO: add logic
+    todo!()
 }

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -42,15 +42,13 @@ pub(crate) async fn handle_connection(stream: TcpStream, address: SocketAddr) {
     let broadcast_incoming = incoming.try_for_each(|msg| {
         debug!("[ws] received message from peer: {:#}", msg);
 
-        let peer_map = Arc::clone(&peer_map);
-
         // if this is a close message, we will not process it
         if let Message::Close(_) = msg {
             return future::ready(Ok(()));
         }
 
         tokio::spawn(async move {
-            messaging::handle_message(peer_map, msg, address).await;
+            messaging::handle_message(msg, address).await;
         });
 
         future::ok(())

--- a/server/src/ws/models.rs
+++ b/server/src/ws/models.rs
@@ -50,6 +50,5 @@ impl Peer {
 /// Data related to a specific peer. This includes identifying information.
 #[derive(Debug, Clone)]
 pub(crate) struct PeerData {
-    pub(crate) token:    String,
     pub(crate) username: String,
 }


### PR DESCRIPTION
These changes heavily simplify the public API of the relay server. It aims to make the server as usable as possible across a wide range of commands; the logic is left to be implemented in the client and runner.

The relay server now only relays messages back and forth, without further processing of the internals. 